### PR TITLE
Add borromean ring signatures py and sol logic

### DIFF
--- a/contracts/Borromean.sol
+++ b/contracts/Borromean.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.4.24;
+pragma experimental ABIEncoderV2;
+
+import "./Curve.sol";
+
+library Borromean{
+
+  function Borr(uint256[2] pubkey, uint256 s, uint256 e)
+  internal view 
+  returns(uint256[2]){
+    Curve.G1Point memory sG = Curve.g1mul(Curve.P1(), s);
+    Curve.G1Point memory eP = Curve.g1mul(Curve.G1Point(pubkey[0], pubkey[1]), e);
+    Curve.G1Point memory R = Curve.g1add(sG, Curve.g1neg(eP));
+    return [R.X, R.Y];
+  }
+
+  function VerifyProof(uint256[2][][] rings, uint256[][] tees, uint256 e0, uint256 message)
+  public view
+  returns(bool)
+  {
+    uint256[2] memory R;
+    uint256 n = rings.length;
+    uint256[2][] memory R_0 = new uint[2][](n);
+    for (uint256 i = 0; i < n; i ++){
+      uint256 e = e0;
+      for (uint256 j = 0; j < tees[i].length; j ++){
+        R = Borr(rings[i][j], tees[i][j], e);
+        e = uint256(keccak256(abi.encodePacked(R, message))) % Curve.N();
+      }
+      R_0[i] = R;
+    }
+    return e0 == (uint256(keccak256(abi.encodePacked(R_0, message))) % Curve.N());
+  }
+}

--- a/pysolcrypto/borromean.py
+++ b/pysolcrypto/borromean.py
@@ -1,0 +1,126 @@
+from .altbn128 import *
+from .utils import hashs
+"""
+This implements Borromean Ring Signatures which is 
+a generalization of AOS Ring Signatures scheme.
+
+Ring is a list of public keys.
+
+  {P_0, P_1, .., P_m}
+
+Having set of rings and prover prooves that she knows a private key
+for each set.
+
+Set of rings:
+
+  {P_00, P_01, .., P_0k}
+  {P_10, P_11, .., P_1l}
+  ...
+  {P_n0, P_n1, .., P_nm}
+
+Prover provides signature list for each ring  along with a seed value.
+Instead of providing e value for each ring common seeed is used for
+signing and verification.
+
+Signing completes with two phases
+1. Calculating common seed value
+2. Closing the ring with the known private key
+
+Original paper:
+
+- https://pdfs.semanticscholar.org/4160/470c7f6cf05ffc81a98e8fd67fb0c84836ea.pdf
+  Gregory Maxwell, Andrew Poelstra
+
+In this implementations edge references are not included in hash data
+as suggested below.
+
+- https://cryptoservices.github.io/cryptography/2017/07/21/Sigs.html
+
+Other implementation details:
+- Indice of common seed value is 0 for each ring.
+"""
+
+hashx = lambda *x, msg: hashsn(*(masint(*x) + [msg] if msg is not None else masint(*x)))
+masint = lambda *x: [asint(item) for sublist in x for item in sublist]
+
+
+def borromean_ring_gen(n=4, m=[2, 2, 2, 2]):
+  if isinstance(m, int):
+    m = [m] * n
+  assert len(m) == n
+  from random import randint
+  rings = []
+  pairs = []
+  for i in range(n):
+    secrets = [randsn() for _ in range(m[i])]
+    ring = [sbmul(s) for s in secrets]
+    i = randint(0, m[i] - 1)
+    rings.append(ring)
+    pairs.append((ring[i], secrets[i]))
+  return rings, pairs
+
+
+def borromean_ring_verify(rings, e_0, s_mat, msg=None):
+  assert isinstance(e_0, int)
+  assert msg is None or isinstance(msg, int)
+  assert len(rings) == len(s_mat) and len(rings) > 0
+  R_0 = [(0, 0)] * len(rings)
+  for i in range(len(rings)):
+    e = e_0
+    for j in range(len(rings[i])):
+      assert len(s_mat[i]) == len(rings[i]) and len(rings[i]) > 0
+      sG = multiply(G1, s_mat[i][j])
+      eP = multiply(rings[i][j], e)
+      R = add(sG, negp(eP))
+      e = hashx(R, msg=msg)
+    R_0[i] = R
+  e_00 = hashx(*R_0, msg=msg)
+  return e_0 == e_00
+
+
+def borromean_ring_sign(rings, pairs, msg=None):
+  assert msg is None or isinstance(msg, int)
+  assert len(pairs) == len(rings) and len(rings) > 0
+  n = len(rings)
+  ring_s_mat = [[randsn() for p in ring] for ring in rings]
+  ring_e_mat = [[0] * len(ring) for ring in rings]
+  ring_e_mat = [[0] * len(ring) for ring in rings]
+  ring_alphas = [randsn() for _ in range(n)]
+  # phase one: find the common e aka e_0
+  R_i = [[(0, 0)] for _ in range(n)]
+  for i in range(n):
+    assert len(rings[i]) > 0
+    j = rings[i].index(pairs[i][0])
+    first_it = True
+    while first_it or j != 0:
+      if first_it:
+        R_i[i] = multiply(G1, ring_alphas[i])
+        first_it = False
+      else:
+        sG = multiply(G1, ring_s_mat[i][j])
+        eP = multiply(rings[i][j], ring_e_mat[i][j])
+        R_i[i] = add(sG, negp(eP))
+      j = (j + 1) % len(rings[i])
+      ring_e_mat[i][j] = hashx(R_i[i], msg=msg)
+  e_0 = hashx(*R_i, msg=msg)
+  # phase two: close the ring
+  # TODO optimization required
+  for i in range(n):
+    j = rings[i].index(pairs[i][0])
+    first_it = True
+    for _ in range(len(rings[i])):
+      e = 0
+      if first_it:
+        R = multiply(G1, ring_alphas[i])
+        e = hashx(R, msg=msg)
+        first_it = False
+      else:
+        sG = multiply(G1, ring_s_mat[i][j])
+        eP = multiply(rings[i][j], ring_e_mat[i][j])
+        R = add(sG, negp(eP))
+        e = hashx(R, msg=msg)
+      j = (j + 1) % len(rings[i])
+      ring_e_mat[i][j] = e if j != 0 else e_0
+    ring_s_mat[i][j] = addmodn(
+        mulmodn(ring_e_mat[i][j], pairs[i][1]), ring_alphas[i])
+  return e_0, ring_s_mat

--- a/test/test_borromean.py
+++ b/test/test_borromean.py
@@ -1,0 +1,101 @@
+import unittest
+
+from pysolcrypto.altbn128 import randsn, addmodp, asint
+from pysolcrypto.borromean import *
+
+
+class BorromeanRingTest(unittest.TestCase):
+
+  def test_borromean(self):
+    msg = randsn()
+    rings, pairs = borromean_ring_gen(n=4, m=4)
+    e, s_mat = borromean_ring_sign(rings, pairs, msg=msg)
+    self.assertTrue(borromean_ring_verify(rings, e, s_mat, msg=msg))
+
+  def test_borromean_with_bad_message(self):
+    msg = randsn()
+    rings, pairs = borromean_ring_gen(n=4, m=4)
+    e, s_mat = borromean_ring_sign(rings, pairs, msg=msg)
+    bad_msg = addmodp(msg,1)
+    self.assertFalse(borromean_ring_verify(rings, e, s_mat, msg=bad_msg))
+
+class RangeProofTest(unittest.TestCase):
+
+  def test_range_proof(self):
+    final, commitments, e, s_mat = self.range_proof_create(3, N=8)
+    ret = self.range_proof_verify(final, commitments, e, s_mat)
+    self.assertTrue(ret)
+
+  def range_proof_create(self, value, blindings=None, N=16):
+    base = 2
+    bits = self.convert_base(value, base, N)
+    rings = [[[0,0] for _ in range(base)] for _ in range(N)]
+    pairs = []
+    commitments = [[0,0] for _ in range(N)]
+    final_commitment = None
+    for i in range(N):
+      subv = bits[i] * 2**i
+      commitments[i], r = self.pedersen_c(subv, blindings[i] if blindings != None else None)
+      C_1 = add(commitments[i], negp(multiply(self.H(), 2**i)))
+      rings[i] = [commitments[i], C_1]
+      pairs.append((rings[i][0 if subv == 0 else 1], r))
+      final_commitment = add(final_commitment, commitments[i])
+    e, s_mat = borromean_ring_sign(rings, pairs, msg=None)
+    return final_commitment, commitments, e, s_mat
+
+  def range_proof_verify(self, final, commitments, e, s_mat):
+    base = 2
+    N = len(commitments)
+    rings = [[[0,0] for _ in range(base)] for _ in range(N)]
+    expected_final = None
+    for i in range(N):
+      rings[i][0] = commitments[i]
+      rings[i][1] = add(commitments[i], negp(multiply(self.H(), 2**i)))
+      expected_final = add(expected_final, commitments[i])
+    ret = borromean_ring_verify(rings, e, s_mat, msg=None)
+    return ret and expected_final == final
+
+  def H(self):
+    from pysolcrypto.utils import hashs
+    from pysolcrypto.altbn128 import hashtopoint, G1
+    h = hashpn(G1)
+    return hashtopoint(h)
+
+  def pedersen_c(self, v, r=None):
+    from pysolcrypto.altbn128 import add, multiply, G1, randsn
+    if r is None:
+      r = randsn()
+    return add(multiply(G1,r), multiply(self.H(), v)), r
+
+  def convert_base(self, value, base, n):
+    digits = []
+    i = 0
+    while i < n:
+      i += 1
+      if value == 0:
+        digits.append(0)
+        continue
+      digits.append(value % base)
+      value = value // base
+    return digits
+
+
+# class SolidityTest(unittest.TestCase):
+  
+#   def test_solidity(self):
+#     from web3 import Web3, HTTPProvider
+#     pasint = lambda p: (asint(p[0]), asint(p[1].n))
+#     mpasint = lambda *mp: [list(pasint(p)) for p in mp]
+#     serring = lambda *x: [mpasint(*sublist) for sublist in x]
+#     w3 = Web3(HTTPProvider(''))
+#     abi = '[{"constant":true,"inputs":[{"name":"rings","type":"uint256[2][][]"},{"name":"tees","type":"uint256[][]"},{"name":"e0","type":"uint256"},{"name":"message","type":"uint256"}],"name":"VerifyProof","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"}]'
+#     adr = Web3.toChecksumAddress('')
+#     c = w.eth.contract(abi=abi,address=adr)
+#     msg = randsn()
+#     rings, pairs = borromean_ring_gen(n=4, m=2)
+#     e, s_mat = borromean_ring_sign(rings, pairs, msg=msg)
+#     self.assertTrue(c.functions.VerifyProof(serring(*rings), s_mat, e, 0).call())
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
I have implemented borromean ring signatures and added range proof example to tests. I tried to be consistent with previous implementations in terms of the form of coding. There is also commented out test for solidity verification using web3py.

Few details

- Edge references are not included in hash input assuming the order as is.
- In solidity only verification logic is available.

Related readings

- [Original paper](https://pdfs.semanticscholar.org/4160/470c7f6cf05ffc81a98e8fd67fb0c84836ea.pdf)
- [Confidential Transactions](https://cryptoservices.github.io/cryptography/2017/07/21/Sigs.html)
- [Confidential Assets](https://blockstream.com/bitcoin17-final41.pdf)






